### PR TITLE
Chore: 도커 컨테이너 포트 매칭 8080:8080에서 80:8080로 수정

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: ${DOCKER_USERNAME}/snap-ticket:${TAG}
     container_name: snap-ticket
     ports:
-      - "8080:8080"
+      - "80:8080"
     env_file:
       - .env
     environment:
@@ -13,4 +13,3 @@ services:
     volumes:
       - /home/ubuntu/logs:/home/logs  # 로그 파일 저장 디렉토리
     restart: always
-    


### PR DESCRIPTION
## 📌 개요
도커 컨테이너 포트 매칭 8080:8080에서 80:8080로 수정

## ✅ 변경 사항
- [x] docker-compose.yml 수정 

## 📎 관련 이슈
- closes #이슈번호